### PR TITLE
add c++11 as std to the default_options

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('RemapFrames',
         'cpp',
-        default_options : 'buildtype=release',
+        default_options : ['buildtype=release', 'c_std=c11', 'cpp_std=c++11'],
         license : 'BSD-2-Clause',
         version : '1')
 


### PR DESCRIPTION
no more errors when building, e.g.
```
In file included from ../VSPlugin.cpp:1:
../Common.h:15:6: warning: scoped enumerations are a C++11 extension [-Wc++11-extensions]
enum class MismatchCauses {
     ^
../Common.h:23:6: warning: scoped enumerations are a C++11 extension [-Wc++11-extensions]
enum class Filter {
     ^
2 warnings generated.```